### PR TITLE
Add performance profiles

### DIFF
--- a/Emus/PORTS/config.json
+++ b/Emus/PORTS/config.json
@@ -1,15 +1,29 @@
 {
-"label":"PORTS",
-"icon":"icon.png",
-"iconsmall":"",
-"iconlist":"",
-"background":"",
-"themecolor":"61A8DD",
-"launch":"launch.sh",
-"rompath":"../../Roms/PORTS",
-"imgpath":"../../Imgs/PORTS",
-"useswap":1,
-"shortname":0,
-"hidebios":1,
-"extlist":"sh"
+    "label":"PORTS",
+    "icon":"icon.png",
+    "iconsmall":"",
+    "iconlist":"",
+    "background":"",
+    "themecolor":"61A8DD",
+    "launch":"launch_balanced.sh",
+    "rompath":"../../Roms/PORTS",
+    "imgpath":"../../Imgs/PORTS",
+    "useswap":1,
+    "shortname":0,
+    "hidebios":1,
+    "extlist":"sh",
+    "launchlist": [
+        {
+            "name": "Battery Saver",
+            "launch": "launch_batterysaver.sh"
+        },
+        {
+            "name": "Balanced",
+            "launch": "launch_balanced.sh"
+        },
+        {
+            "name": "High Performance",
+            "launch": "launch_performance.sh"
+        }
+    ]
 }

--- a/Emus/PORTS/launch.sh
+++ b/Emus/PORTS/launch.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-source /mnt/SDCARD/System/etc/ex_config
-
-PORTS_DIR=/mnt/SDCARD/Roms/PORTS
-cd $PORTS_DIR/
-
-/bin/sh "$@"

--- a/Emus/PORTS/launch_balanced.sh
+++ b/Emus/PORTS/launch_balanced.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+source /mnt/SDCARD/System/etc/ex_config
+
+echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 600000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+echo 1200000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+
+PORTS_DIR=/mnt/SDCARD/Roms/PORTS
+cd $PORTS_DIR/
+
+/bin/sh "$@"

--- a/Emus/PORTS/launch_batterysaver.sh
+++ b/Emus/PORTS/launch_batterysaver.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+source /mnt/SDCARD/System/etc/ex_config
+
+echo conservative > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 408000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+echo 816000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+
+PORTS_DIR=/mnt/SDCARD/Roms/PORTS
+cd $PORTS_DIR/
+
+/bin/sh "$@"

--- a/Emus/PORTS/launch_performance.sh
+++ b/Emus/PORTS/launch_performance.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+source /mnt/SDCARD/System/etc/ex_config
+
+echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 1008000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+echo 2000000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+
+PORTS_DIR=/mnt/SDCARD/Roms/PORTS
+cd $PORTS_DIR/
+
+/bin/sh "$@"


### PR DESCRIPTION
This pull request adds three CPU frequency and governor profiles for PortMaster. Keep in mind that these will only work when launching through the PortMaster "emulator" (i.e. launching through PORTS under the Roms menu), not through the Ports menu:

| **Profile**        | **Governor** | **MinFreq** | **MaxFreq** |
|--------------------|--------------|-------------|-------------|
| **Battery Saver**    | Conservative | 408000      | 816000      |
| **Balanced**         | OnDemand     | 600000      | 1200000     |
| **High Performance** | OnDemand     | 1008000     | 2000000     |